### PR TITLE
errbot: added timezone

### DIFF
--- a/arxiv_completeness.py
+++ b/arxiv_completeness.py
@@ -29,6 +29,7 @@ class ArxivCompleteness(CrontabMixin, BotPlugin):
     """
 
     CRONTAB = ["0 10 * * 1-5 .daily_check"]
+    TIMEZONE = "Europe/Zurich"
 
     @arg_botcmd("--from-date", dest="from_date", type=str, default=None)
     @arg_botcmd("--to-date", dest="to_date", type=str, default=None)


### PR DESCRIPTION
Has found in code or errcron plugin. 
One can use `TIMEZONE` to define it
https://github.com/attakei/errcron/blob/a3938fc7d051daefb6813588fcbeb9592bd00c9a/errcron/bot.py#L21C24-L21C37

May make sense to also adapt https://github.com/cern-sis/errbot-reminder to use `errcron`